### PR TITLE
#25 Simplify SGFFileFilter. Add tests for it.

### DIFF
--- a/src/main/java/leelawatcher/gui/SGFFileFilter.java
+++ b/src/main/java/leelawatcher/gui/SGFFileFilter.java
@@ -32,23 +32,10 @@ public class SGFFileFilter extends javax.swing.filechooser.FileFilter {
   }
 
   public boolean accept(java.io.File file) {
-    String name = file.getName();
-    if ((name.indexOf(".sgf") == (name.length() - 4)) ||
-        (name.indexOf(".SGF") == (name.length() - 4)) ||
-        (name.indexOf(".Sgf") == (name.length() - 4)) ||
-        (name.indexOf(".sGf") == (name.length() - 4)) ||
-        (name.indexOf(".sgF") == (name.length() - 4)) ||
-        (name.indexOf(".sGF") == (name.length() - 4)) ||
-        (name.indexOf(".SgF") == (name.length() - 4)) ||
-        (name.indexOf(".SGf") == (name.length() - 4))) {
-      return true;
-    } else {
-      return false;
-    }
+    return file.getName().toUpperCase().endsWith(".SGF");
   }
 
   public String getDescription() {
     return "Smart Go Format";
   }
-
 }

--- a/src/test/java/leelawatcher/gui/SGFFileFilterTest.java
+++ b/src/test/java/leelawatcher/gui/SGFFileFilterTest.java
@@ -1,0 +1,28 @@
+package leelawatcher.gui;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Barry Becker
+ */
+public class SGFFileFilterTest {
+
+    private SGFFileFilter sgfFilter = new SGFFileFilter();
+
+    @Test
+    public void testNonSGFFile() {
+        assertFalse(sgfFilter.accept(new File("fff.txt")));
+    }
+
+    @Test
+    public void testValidSGFFile() {
+        assertTrue(sgfFilter.accept(new File("fff.sgF")));
+        assertTrue(sgfFilter.accept(new File("fff.SGF")));
+        assertTrue(sgfFilter.accept(new File("xyz123.SGf")));
+    }
+}


### PR DESCRIPTION
Simplified the implementation of SGFFileFilter and added unit tests for it.

BTW, I think it's better to only capitalize the first letter in acronyms in classnames. i.e. SgfFileFilter would be preferable to SGFFileFilter. Sometimes there are multiple acronyms concatenated. For example, HtmlSgfFilter is easier to read than HTMLSGFFilter.