### PR TITLE
Fix the parser for use with v18 of autogtp (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Before you can use the LeelaWatcher you must first obtain a current copy of Leel
 
 You will also need to install the [Java Runtime Environment](http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html)
 
-After you have Java, Leela Zero and autogtp, you can run the latest version of LeelaWatcher ([found here](https://github.com/fsparv/LeelaWatcher/releases))
+After you have Java, Leela Zero and autogtp, you can run the latest version of LeelaWatcher ([found here](https://github.com/fsparv/LeelaWatcher/releases)) or build it locally with `.gradlew assemble`. If you choose to build locally, then the jar can be found in the build/libs directory.
 
 On Linux (what I use) the command looks like this
 
-    java -jar LeelaWatcher-1.1.0.jar /home/gus/leelaz/leela-zero/autogtp/
+    java -jar LeelaWatcher-1.2.0.jar /home/gus/leelaz/leela-zero/autogtp/
     
 Mac should be similar. For those not familiar with java, what that line does is it invokes java and instructs it to run the code found in LeelaWatcher.jar. Everything after LeelaWatcher.jar is passed to the program as [arguments](https://en.wikipedia.org/wiki/Command-line_interface#Arguments)
 
@@ -25,18 +25,18 @@ Two arguments are possible, the first one is the location where LeelaWatcher wil
 
 Here's a Windows example, that assumes that your autogtp is in a folder named `D:\My Folders\Downloads\leela-zero-0.4-window` :
 
-    C:>java -jar LeelaWatcher-1.1.0.jar D:\My Folders\Downloads\leela-zero-0.4-windows autogtp.exe
+    C:>java -jar LeelaWatcher-1.2.0.jar D:\My Folders\Downloads\leela-zero-0.4-windows autogtp.exe
 
 or alternately 
 
     C:> cd D:\My Folders\Downloads\leela-zero-0.4-windows
-    D:\My Folders\Downloads\leela-zero-0.4-windows>java -jar LeelaWatcher-1.1.0.jar . autogtp.exe
+    D:\My Folders\Downloads\leela-zero-0.4-windows>java -jar LeelaWatcher-1.2.0.jar . autogtp.exe
     
 Note that the '.' in the second example is a symbol that means "the current directory." Also if I've messed up the Windows example let me know by filing an issue with an example of the corrected command line(s). I don't use Windows very much, and haven't actually run my program there.
 
 Additional command line options can be seen by passing `--help` or `-h`
 
-    java -jar ~/projects/LeelaWatcher/LeelaWatcher/build/libs/LeelaWatcher-1.1.0.jar --help 
+    java -jar ~/projects/LeelaWatcher/LeelaWatcher/build/libs/LeelaWatcher-1.2.0.jar --help 
     
     Start a LeelaWatcher instance. A prefix of java -jar is presumed for all
     usage below. <dir> specifies where to find autogtp and <cmd> allows
@@ -44,7 +44,7 @@ Additional command line options can be seen by passing `--help` or `-h`
     an exe for example)
     
     Usage:
-     LeelaWatcher-1.1.0-SNAPSHOT.jar [--help] [options] <dir> [<cmd>]
+     LeelaWatcher-1.2.0-SNAPSHOT.jar [--help] [options] <dir> [<cmd>]
     
     Options:
       --no-sgf        Don't save an sgf file for each game

--- a/build.gradle
+++ b/build.gradle
@@ -6,22 +6,20 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.github.jengelman.gradle.plugins:shadow:2.0.1"
+        classpath "com.github.jengelman.gradle.plugins:shadow:2.0.4"
     }
 }
 
-plugins {
-    id "com.github.johnrengelman.shadow" version "2.0.1"
-    id "java"
-    id "application"
-}
-
+apply plugin: 'java'
+apply plugin: 'application'
 mainClassName = 'leelawatcher.gui.LeelaWatcher'
+apply plugin: 'com.github.johnrengelman.shadow'
+
 
 shadowJar {
     baseName = 'LeelaWatcher'
     classifier = null
-    version = '1.1.0'
+    version = '1.2.0'
 }
 
 repositories {
@@ -29,7 +27,11 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:23.5-jre'
-    compile 'com.offbytwo:docopt:0.6.0.20150202'
-    testCompile('junit:junit:4.12')
+    implementation 'com.google.guava:guava:23.5-jre'
+    implementation 'com.offbytwo:docopt:0.6.0.20150202'
+    testImplementation('junit:junit:4.12')
+}
+
+wrapper {
+    gradleVersion = '6.2'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-bin.zip

--- a/src/main/java/leelawatcher/goboard/Board.java
+++ b/src/main/java/leelawatcher/goboard/Board.java
@@ -118,7 +118,7 @@ public class Board {
    * variation.
    */
 
-  public Iterator getPosIter() {
+  public Iterator<Position> getPosIter() {
     return positions.iterator();
   }
 
@@ -140,7 +140,7 @@ public class Board {
     String temp = gm.getBoardSize();
     if (temp.indexOf(':') < 0)
       try {
-        numlines = new Integer(temp);
+        numlines = Integer.parseInt(temp);
       } catch (NumberFormatException e) {
         System.out.println("number format exception reading board size: " + temp + "\n" + e);
         System.exit(0);
@@ -380,7 +380,7 @@ public class Board {
    */
   @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
   public int captureGroup(PointOfPlay p) {
-    Set groupList = enumerateGroup(p);
+    Set<PointOfPlay> groupList = enumerateGroup(p);
     int result = groupList.size();
 
     for (Object aGroupList : groupList) {
@@ -388,7 +388,6 @@ public class Board {
     }
 
     return result;
-
   }
 
   /**
@@ -404,7 +403,7 @@ public class Board {
    * @see MarkablePosition#getGroupSet
    */
 
-  private Set enumerateGroup(PointOfPlay p) {
+  private Set<PointOfPlay> enumerateGroup(PointOfPlay p) {
     return getGroupSet(p);
   }
 
@@ -418,7 +417,7 @@ public class Board {
    * @see MarkablePosition#getGroupSet(PointOfPlay, Set, int)
    */
 
-  private Set getGroupSet(PointOfPlay p) {
+  private Set<PointOfPlay> getGroupSet(PointOfPlay p) {
     MarkablePosition temp = new MarkablePosition(getCurrPos());
     return temp.getGroupSet(p, null, getBoardSize());
   }

--- a/src/main/java/leelawatcher/goboard/Board.java
+++ b/src/main/java/leelawatcher/goboard/Board.java
@@ -16,6 +16,7 @@
 
 package leelawatcher.goboard;
 
+import leelawatcher.goboard.move.Move;
 import leelawatcher.scorer.AbstractRules;
 import leelawatcher.scorer.QuickRules;
 import leelawatcher.scorer.Rules;
@@ -433,11 +434,11 @@ public class Board {
    *                    false if white should move first.
    */
   public void setUp(List<PointOfPlay> white, List<PointOfPlay> black, List<PointOfPlay> empty, boolean blackToMove) {
-    Move initalMove = this.gm.getCurrMove();
+    Move initialMove = this.gm.getCurrMove();
     white.forEach(p -> this.gm.doSetup(Move.MOVE_WHITE, p.getX(), p.getY(), blackToMove));
     black.forEach(p -> this.gm.doSetup(Move.MOVE_BLACK, p.getX(), p.getY(), blackToMove));
     empty.forEach(p -> this.gm.doSetup(Move.EMPTY, p.getX(), p.getY(), blackToMove));
-    if (initalMove == this.gm.getCurrMove()) {
+    if (initialMove == this.gm.getCurrMove()) {
       // was already a setup move to which we added points, need to recreate the existing position.
       positions.remove(currPos);
       positions.add(new Position(positions.get(currPos), this.gm.getCurrMove()));

--- a/src/main/java/leelawatcher/goboard/Game.java
+++ b/src/main/java/leelawatcher/goboard/Game.java
@@ -18,6 +18,9 @@ package leelawatcher.goboard;
 
 
 import leelawatcher.goboard.move.Move;
+import leelawatcher.goboard.move.MoveNode;
+import leelawatcher.goboard.move.RootNode;
+import leelawatcher.goboard.move.SetupNode;
 import leelawatcher.sgf.SGFbuilder;
 
 import java.time.format.DateTimeFormatter;
@@ -131,7 +134,7 @@ public class Game {
 
     _ruleSet = "Japanese";            // default probably will be japaneese
     tradHandi = true;               // traditions are defaults
-    _gameRoot = new Move();     // a white pass to root the game tree
+    _gameRoot = new RootNode();     // a white pass to root the game tree
     gameOver = false;               // we have only just begun!
     whiteLast = true;               // this makes it black's move
     currMove = _gameRoot;
@@ -196,7 +199,7 @@ public class Game {
       }
     }
 
-    currMove = new Move(xcoor, ycoor, stoneColor, prevMove);
+    currMove = new MoveNode(xcoor, ycoor, stoneColor, prevMove);
 
     whiteLast = !whiteLast;
 
@@ -206,7 +209,7 @@ public class Game {
 
   public void doSetup(char type, int xcoor, int ycoor, boolean blackToMove) {
     if (!currMove.isSetup()) {
-      currMove = new Move(prevMove);
+      currMove = new SetupNode(prevMove);
     }
     switch (type) {
       case Move.EMPTY      : currMove.setupEmpty(xcoor,ycoor); break;

--- a/src/main/java/leelawatcher/goboard/Game.java
+++ b/src/main/java/leelawatcher/goboard/Game.java
@@ -17,6 +17,7 @@
 package leelawatcher.goboard;
 
 
+import leelawatcher.goboard.move.Move;
 import leelawatcher.sgf.SGFbuilder;
 
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/leelawatcher/goboard/Game.java
+++ b/src/main/java/leelawatcher/goboard/Game.java
@@ -104,8 +104,8 @@ public class Game {
    *
    * @param nameWhite The name of the player using white stones.
    * @param nameBlack The name of the player using black stones.
-   * @param handicap  The handicap for the game
-   * @param ptsKomi
+   * @param handicap The handicap for the game
+   * @param ptsKomi Amount of komi to use
    */
   public Game(String nameWhite, String nameBlack, int handicap,
               float ptsKomi) {
@@ -563,14 +563,6 @@ public class Game {
     _boardSizeY = square;
   }
 
-  // This method not yet supported.
-  //
-  //    public void setBoardSize(int x, int y)
-  //    {
-  //	     _boardSizeX = x;
-  //	     _boardSizeY = y;
-  //    }
-
   /**
    * A string representation of the size of the board.
    *
@@ -899,20 +891,4 @@ public class Game {
     dPrintMoves(_gameRoot);
   }
 
-
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/main/java/leelawatcher/goboard/MarkablePosition.java
+++ b/src/main/java/leelawatcher/goboard/MarkablePosition.java
@@ -15,6 +15,7 @@
  */
 package leelawatcher.goboard;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -57,9 +58,7 @@ public class MarkablePosition extends Position {
    * All mark up bits are set to 0 completely erasing all marks.
    */
   public void clearMarks() {
-    for (int i = 0; i < marks.length; i++) {
-      marks[i] = 0;
-    }
+    Arrays.fill(marks, 0);
   }
 
   /**
@@ -146,9 +145,9 @@ public class MarkablePosition extends Position {
    * @param boardSize The size of the board
    * @return A HashSet of PointOfPlay objects describing the group
    */
-  public Set getGroupSet(PointOfPlay p, Set<PointOfPlay> members, int boardSize) {
+  public Set<PointOfPlay> getGroupSet(PointOfPlay p, Set<PointOfPlay> members, int boardSize) {
     if (members == null) {
-      members = new HashSet<>();
+      members = new HashSet<PointOfPlay>();
       clearMarks();                // NOTE that this clears all marks
     }
 

--- a/src/main/java/leelawatcher/goboard/Move.java
+++ b/src/main/java/leelawatcher/goboard/Move.java
@@ -36,28 +36,26 @@ import java.util.List;
  * the SGF file format.
  * <p>
  * <p><b><i>This class is due for a refactoring</i></b>, it does too much. It
- * should be devided into a MoveNode, a SetupNode and a RootNode which inherit
+ * should be divided into a MoveNode, a SetupNode and a RootNode which inherit
  * from an AbstractNode. This will also bring the object model in closer
- * corespondence with the structure of an SGF file.
+ * correspondence with the structure of an SGF file.
  * <p>
  * <p>There will also be a need to write a GameInfo class and provide a place
- * to attach it to the first distinguishing move in a tree of games begining
+ * to attach it to the first distinguishing move in a tree of games beginning
  * with the move sequence. This will not be necessary until either loading of
  * ANY SGF file is supported, or creation of multi-game trees is supported.
  * <p>
  * <p> It is important to note that while some methods here will work for
  * board sizes over or under 19x19 <b>only 19x19 is fully supported</b> by all
  * the methods in this class at this time. Some Functionality may need to be
- * swaped out to other classes (particularly in the realm of generating
+ * swapped out to other classes (particularly in the realm of generating
  * SGF output) to support other board sizes.
  *
  * @author Patrick G. Heck
  * @version 0.1
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
-public class Move
-
-{
+public class Move {
   /**
    * <code>MOVE_WHITE</code> is the character that should be used to
    * designate a white move throughout the application.
@@ -241,7 +239,7 @@ public class Move
     moveNum = parentMove.getMoveNum();    // find out who is before us
     moveNum++;                            // we are one more move into tree
 
-    parent = parentMove;                  // Supprised?
+    parent = parentMove;                  // Suprised?
 
     parentMove.addChild(this);            // inform Parent of new child
 

--- a/src/main/java/leelawatcher/goboard/PointOfPlay.java
+++ b/src/main/java/leelawatcher/goboard/PointOfPlay.java
@@ -15,6 +15,8 @@
  */
 package leelawatcher.goboard;
 
+import leelawatcher.goboard.move.Move;
+
 /**
  * The location of a point on a go board.
  * <p>

--- a/src/main/java/leelawatcher/goboard/Position.java
+++ b/src/main/java/leelawatcher/goboard/Position.java
@@ -16,6 +16,8 @@
 
 package leelawatcher.goboard;
 
+import leelawatcher.goboard.move.Move;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;

--- a/src/main/java/leelawatcher/goboard/move/AbstractMoveNode.java
+++ b/src/main/java/leelawatcher/goboard/move/AbstractMoveNode.java
@@ -1,0 +1,351 @@
+/*
+    Copyright 2017 Patrick G. Heck
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+package leelawatcher.goboard.move;
+
+import leelawatcher.goboard.PointOfPlay;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * This class will be used to model a tree of Moves.
+ * <p>
+ * The branches of the tree represent variations, or moves undone. The
+ * tree may have any number of leaves at each node. Tree traversal is
+ * not included as a method. The order of the nodes is based entirely on
+ * order of entry since there is no sensible way to sort Moves.
+ * <p>
+ * <p>Setup nodes occur within the tree and any Move related information stored
+ * in a node containing setup information should be ignored. Setup nodes
+ * should not add to the MoveNum variable as a setup does not constitute a
+ * Move. Setups in the middle of the tree are allowed in order to support
+ * the SGF file format.
+ * <p>
+ * <p>There will also be a need to write a GameInfo class and provide a place
+ * to attach it to the first distinguishing move in a tree of games beginning
+ * with the move sequence. This will not be necessary until either loading of
+ * ANY SGF file is supported, or creation of multi-game trees is supported.
+ * <p>
+ * <p> It is important to note that while some methods here will work for
+ * board sizes over or under 19x19 <b>only 19x19 is fully supported</b> by all
+ * the methods in this class at this time. Some Functionality may need to be
+ * swapped out to other classes (particularly in the realm of generating
+ * SGF output) to support other board sizes.
+ *
+ * @author Patrick G. Heck
+ * @version 0.1
+ */
+public class AbstractMoveNode implements Move {
+
+  protected int x;                // horizontal coordinate 0-18
+  protected int y;                // vertical coordinate 0-18
+  protected char color;           // 'B' or 'W' or 'S' or 'R'
+  protected int moveNum;          // depth into the tree
+  protected Move parent;          // Move that came before
+  protected List<Move> children;      // Moves that come after
+  protected String comment;       // Where people demonstrate their (lack of?)
+  //    knowledge
+  protected char colorMoveNext;   // who gets to place the next stone (B||W)
+
+  protected List<PointOfPlay> addBlack;      // vectors to store PointOfPlay objects
+  protected List<PointOfPlay> addWhite;      // in setup nodes.
+  protected List<PointOfPlay> addEmpty;
+
+  // to help keep track of objects, and debug problems, all objects number
+  // their instances.
+  protected static long numInstances = 0;
+  protected long numThis;
+
+  public boolean isSetup() {
+    return (color == SetupNode.MOVE_SETUP);
+  }
+
+  public boolean isRoot() {
+    return (color == RootNode.MOVE_ROOT);
+  }
+
+  public boolean isMove() {
+    return (color == MOVE_WHITE || color == MOVE_BLACK);
+  }
+
+  public boolean isWhite() {
+    return (color == AbstractMoveNode.MOVE_WHITE);
+  }
+
+  public boolean isBlack() {
+    return (color == AbstractMoveNode.MOVE_BLACK);
+  }
+
+  public boolean isPass() {
+    return isPass(x,y);
+  }
+
+  public static boolean isPass(int x, int y) {
+    return ((x == AbstractMoveNode.PASS) && (y == AbstractMoveNode.PASS));
+  }
+
+  public long ID() {
+    return numThis;
+  }
+
+  public void dPrint() {
+    Iterator<PointOfPlay> empty = addEmpty.iterator();
+    Iterator<PointOfPlay> white = addWhite.iterator();
+    Iterator<PointOfPlay> black = addBlack.iterator();
+    int numChildren = children.size();
+
+    System.out.println("Move instance " + numThis + " of "
+        + numInstances + ":");
+    System.out.println("moveNum=" + moveNum);
+    System.out.println("x=" + x);
+    System.out.println("y=" + y);
+    System.out.println("color=" + color);
+    System.out.println("parent=/n- - - - - - -");
+    parent.dPrint();
+    System.out.println("- - - - - - -");
+    System.out.println("There are " + numChildren + " children");
+    System.out.println("comment=" + comment);
+    System.out.println("Setup vectors:");
+    System.out.print("addEmpty=");
+    while (empty.hasNext())
+      System.out.print(empty.next());
+    System.out.print("\naddWhite=");
+    while (white.hasNext())
+      System.out.print(white.next());
+    System.out.print("\naddBlack=");
+    while (black.hasNext())
+      System.out.print(black.next());
+    System.out.println("\n----------------");
+  }
+
+  public int numChildren() {
+    return children.size();
+  }
+
+  public void removeChild(Move which) {
+    children.remove(which);
+  }
+
+  public void addChild(Move child) {
+    children.add(child);
+  }
+
+  public void setupEmpty(int x, int y) {
+    setup(x, y, addEmpty, addWhite, addBlack);
+  }
+
+  private void setup(int x, int y, List<PointOfPlay> target, List<PointOfPlay> other1, List<PointOfPlay> other2) {
+    PointOfPlay temp = new PointOfPlay(x, y);
+
+    if (this.isMove())             // setup nodes and Moves MUST not be
+      return;                      // mixed!
+
+    // check if point is already in list of empty points
+    for (PointOfPlay point : target) {
+      if (point.equals(temp))
+        return;
+    }
+
+    // now remove any duplicates
+    remDup(temp, other1);
+    remDup(temp, other2);
+
+    target.add(temp);            // if we get here the point is unique
+    // so we can go ahead and add it
+  }
+
+  private void remDup(PointOfPlay temp, List<PointOfPlay> list) {
+    for (PointOfPlay thisOne : list) {
+      if (thisOne.equals(temp)) {
+        addWhite.remove(thisOne);
+        break;
+      }
+    }
+  }
+
+  public void setupWhite(int x, int y) {
+    setup(x, y, addWhite, addEmpty, addBlack);
+  }
+
+  public void setupBlack(int x, int y) {
+    setup(x, y, addBlack, addWhite, addEmpty);
+  }
+
+  public void undoSetupEmpty(int x, int y) {
+    PointOfPlay temp = new PointOfPlay(x, y);
+
+    if (this.isMove())             // setup nodes and moves MUST not be
+      return;                    // mixed!
+
+    remDup(temp, addEmpty);
+  }
+
+  public void undoSetupWhite(int x, int y) {
+    PointOfPlay temp = new PointOfPlay(x, y);
+
+    if (this.isMove())             // setup nodes and Moves MUST not be
+      return;                    // mixed!
+
+    remDup(temp, addWhite);
+  }
+
+  public void undoSetupBlack(int x, int y) {
+    PointOfPlay temp = new PointOfPlay(x, y);
+    Iterator<PointOfPlay> points = addBlack.iterator();
+
+    if (this.isMove())             // setup nodes and Moves MUST not be
+      return;                    // mixed!
+
+    while (points.hasNext())        // check if point is already in list
+    {
+      PointOfPlay thisOne = (PointOfPlay) points.next();
+      if (thisOne.equals(temp)) {
+        addBlack.remove(thisOne);
+        return;
+      }
+    }
+  }
+
+  public int yEnglish() {
+    return (y + 1);
+  }
+
+  public char xEnglish() {
+    if (x >= 9)
+      return (char) ('a' + x + 1); // This is a convention used in books.
+      // The letter i is skipped, probably
+      // because of it's similarity to j
+      // in some type faces. Since fonts may
+      // be customizable it should be kept.
+    else
+      return (char) ('a' + x);
+  }
+
+  public char xSGF(int xNum) {
+    return (xNum == AbstractMoveNode.PASS) ? ' ' : (char) ('a' + xNum);
+  }
+
+  public char ySGF(int yNum) {
+    return (yNum == AbstractMoveNode.PASS) ? ' ' : (char) ('a' + 18 - yNum); // SGF format a,a is upper left corner
+  }
+
+  public String toString() {
+    StringBuilder temp = new StringBuilder();
+
+    if (this.isMove()) {
+      temp.append(color);
+      temp.append("[").append(xSGF(x)).append(ySGF(y)).append("]");
+    } else {
+      if (addEmpty.size() > 0) {
+        Iterator<PointOfPlay> points = addEmpty.iterator();
+        temp.append("AE");
+        while (points.hasNext()) {
+          PointOfPlay thisOne = points.next();
+          temp.append("[").append(xSGF(thisOne.getX())).append(ySGF(thisOne.getY())).append("]");
+        }
+      }
+      if (addWhite.size() > 0) {
+        Iterator<PointOfPlay> points = addWhite.iterator();
+        temp.append("AW");
+        while (points.hasNext()) {
+          PointOfPlay thisOne = points.next();
+          temp.append("[").append(xSGF(thisOne.getX())).append(ySGF(thisOne.getY())).append("]");
+        }
+      }
+      if (addBlack.size() > 0) {
+        Iterator<PointOfPlay> points = addBlack.iterator();
+        temp.append("AB");
+        while (points.hasNext()) {
+          PointOfPlay thisOne = points.next();
+          temp.append("[").append(xSGF(thisOne.getX())).append(ySGF(thisOne.getY())).append("]");
+        }
+      }
+    }
+    if (!"".equals(comment))
+      temp.append("C[").append(comment).append("]");
+
+    return temp.toString();
+  }
+
+  public Move next() {
+    if (children.size() == 0)
+      return this;
+    return children.get(0);
+  }
+
+  public Move next(int variation) {
+    if (variation >= 0 && variation <= children.size())
+      return children.get(variation);
+    else if (children.size() == 0)
+      return this;
+    else
+      return children.get(0);
+  }
+
+  public Move getParent() {
+    return parent;
+  }
+
+  public void setColorMoveNext(char nextColor) {
+    if ((color == SetupNode.MOVE_SETUP) || (color == RootNode.MOVE_ROOT)) {
+      colorMoveNext = nextColor;
+    } else {
+      String msg = "Can only set colorNextMove in setup/root Moves!";
+      throw new UnsupportedOperationException(msg);
+    }
+  }
+
+  public char getColorNextMove() {
+    return colorMoveNext;
+  }
+
+  public int getMoveNum() {
+    return moveNum;
+  }
+
+  public void setComment(String aComment) {
+    comment = aComment;
+  }
+
+  public String getComment() {
+    return comment;
+  }
+
+  public int getX() {
+    return x;
+  }
+
+  public int getY() {
+    return y;
+  }
+
+  public char getColor() {
+    return color;
+  }
+
+  public List<PointOfPlay>[] getSetupInfo() {
+    @SuppressWarnings("unchecked")
+    List<PointOfPlay>[] tmp = new List[3];
+
+    tmp[0] = Collections.unmodifiableList(addEmpty);
+    tmp[1] = Collections.unmodifiableList(addBlack);
+    tmp[2] = Collections.unmodifiableList(addWhite);
+
+    return tmp;
+  }
+}

--- a/src/main/java/leelawatcher/goboard/move/Move.java
+++ b/src/main/java/leelawatcher/goboard/move/Move.java
@@ -14,7 +14,9 @@
     limitations under the License.
  */
 
-package leelawatcher.goboard;
+package leelawatcher.goboard.move;
+
+import leelawatcher.goboard.PointOfPlay;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/leelawatcher/goboard/move/MoveNode.java
+++ b/src/main/java/leelawatcher/goboard/move/MoveNode.java
@@ -1,0 +1,80 @@
+/*
+    Copyright 2017 Patrick G. Heck
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+package leelawatcher.goboard.move;
+
+import java.util.ArrayList;
+
+
+public class MoveNode extends AbstractMoveNode {
+
+  /**
+   * Constructor to use for normal Moves.
+   * <p>
+   * This constructor creates a "normal" move by adding it to
+   * <code>parentMove</code>, setting the x and y coordinates and
+   * setting the color. It is not legal to try to attach a black move
+   * to a black parent move, or a white move to a white parent move,
+   * and only black and white moves may be created with this constructor
+   * (no setup or root nodes). In the future, this constructor may set
+   * the vectors for setup moves to null since they shouldn't be used
+   * on an object created with this constructor.
+   *
+   * @param xcoor      The horizontal displacement from the lower left corner
+   * @param ycoor      The vertical displacement from the lower left corner
+   * @param pcolor     The color for this move.
+   * @param parentMove The move to which this move is attached in the game
+   *                   tree.
+   * @throws IllegalArgumentException If pcolor is not <code>Move.MOVE_BLACK</code> or
+   *                                  <code>Move.MOVE_WHITE</code>
+   * @throws IllegalArgumentException If pcolor is of the same color as the parent move
+   */
+  public MoveNode(int xcoor, int ycoor, char pcolor, Move parentMove) {
+    numInstances++;        // keep track of how many have been created
+    numThis = numInstances;
+
+    // On a standard 19x19 board:
+    x = xcoor;             // 0-18 0 on left -1 to resign 19 to pass
+    y = ycoor;             // 0-18 0 on bottom -1 to resign 19 to pass
+
+    if (pcolor != MOVE_BLACK && pcolor != MOVE_WHITE) {
+      String msg = "Moves must be black or white!";
+      throw new IllegalArgumentException(msg);
+    }
+
+    if (parentMove.isMove() && (pcolor == parentMove.getColor())) {
+      String msg = "Attempted to move the same color twice!";
+      throw new IllegalArgumentException(msg);
+    }
+
+    color = pcolor;        // 'B' or 'W'
+
+    moveNum = parentMove.getMoveNum();    // find out who is before us
+    moveNum++;                            // we are one more move into tree
+
+    parent = parentMove;                  // Suprised?
+
+    parentMove.addChild(this);            // inform Parent of new child
+
+    children = new ArrayList<>(1);           // A place to put it's children
+
+    addBlack = new ArrayList<>(1);         // shouldn't be used in move
+    addWhite = new ArrayList<>(1);         // node, and may be set to null
+    addEmpty = new ArrayList<>(1);         // in future versions
+
+    comment = "";
+  }
+}

--- a/src/main/java/leelawatcher/goboard/move/RootNode.java
+++ b/src/main/java/leelawatcher/goboard/move/RootNode.java
@@ -1,0 +1,52 @@
+/*
+    Copyright 2017 Patrick G. Heck
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+package leelawatcher.goboard.move;
+
+import java.util.ArrayList;
+
+public class RootNode extends AbstractMoveNode {
+
+  /**
+   * Constructor to create the root of a game tree.
+   * <p>
+   * Only should be used for root nodes. The color will be set to MOVE_ROOT
+   * and this node is it's own parent. A root move can contain setup Info,
+   * usually handicap placement
+   */
+  public RootNode() {
+
+    numInstances++;        // keep track of how many have been created
+    numThis = numInstances;
+
+    x = PASS;              // since this is the root, no stone is placed
+    y = PASS;              // making it a pass
+
+    color = MOVE_ROOT;   // mark it as a root node (colorless)
+
+    moveNum = 0;         // This is the root Move, not a real Move
+
+    parent = this;       // This is the root Move and thus it's own parent
+
+    children = new ArrayList<>(1);
+
+    addBlack = new ArrayList<>(10);         // Handicaps most often
+    addWhite = new ArrayList<>(10);         // For setup of white stones
+    addEmpty = new ArrayList<>(10);         // For erasure of stones
+
+    comment = "";
+  }
+}

--- a/src/main/java/leelawatcher/goboard/move/SetupNode.java
+++ b/src/main/java/leelawatcher/goboard/move/SetupNode.java
@@ -1,0 +1,68 @@
+/*
+    Copyright 2017 Patrick G. Heck
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+package leelawatcher.goboard.move;
+
+import java.util.ArrayList;
+
+
+public class SetupNode extends AbstractMoveNode {
+
+  /**
+   * Constructor to use for setup Moves.
+   * <p>
+   * Generally a setup move will most commonly occur right after the
+   * root move to place handicap stones if they havnt been placed in
+   * the root move. It is not legal to add setup information to a
+   * standard move and move information cannot be added to a setup move.
+   * This restriction is necessary for compliance with the SGF format.
+   * Setup moves are otherwise allowed anywhere in the game tree, but
+   * they are usually only useful for sgf files that describe problem sets,
+   * or are annotated with alternate positions. Setup information must be
+   * added after the move is created using Move.setupEmpty, Move.setupBlack
+   * or Move.setupWhite methods.
+   *
+   * @param parentMove The move preceding this one in the tree.
+   */
+  @SuppressWarnings("unused")
+  public SetupNode(Move parentMove) {
+    numInstances++;        // keep track of how many have been created
+    numThis = numInstances;
+
+    // On a standard 19x19 board:
+    x = 98;                // 0-18 0 on left -1 to resign 19+ to pass
+    y = 98;                // 0-18 0 on bottom -1 to resign 19+ to pass
+
+    color = MOVE_SETUP;    // 'S' indicates setup Move
+
+    colorMoveNext = parentMove.getColorNextMove();
+
+    moveNum = parentMove.getMoveNum();    // find out who is before us
+    // but don't increment
+
+    parent = parentMove;                  // Supprised?
+    parentMove.addChild(this);            // inform Parent of new child
+
+    children = new ArrayList<>(1);           // A place to put it's children
+
+    addBlack = new ArrayList<>(10);         // Handicaps most often
+    addWhite = new ArrayList<>(10);         // For setup of white stones
+    addEmpty = new ArrayList<>(10);         // For erasure of stones
+
+    comment = "";
+  }
+
+}

--- a/src/main/java/leelawatcher/gui/BoardView.java
+++ b/src/main/java/leelawatcher/gui/BoardView.java
@@ -24,7 +24,7 @@ package leelawatcher.gui;
 
 import leelawatcher.goboard.Board;
 import leelawatcher.goboard.IllegalMoveException;
-import leelawatcher.goboard.Move;
+import leelawatcher.goboard.move.Move;
 import leelawatcher.goboard.PointOfPlay;
 
 import java.awt.*;

--- a/src/main/java/leelawatcher/gui/ImageMaker.java
+++ b/src/main/java/leelawatcher/gui/ImageMaker.java
@@ -95,18 +95,6 @@ public class ImageMaker implements TsbConstants {
 
   // paint a stone at a given coordinate specified in pixels
 
-  //  public void paintStone2D(int x, int y, Color player,
-  //                         int pixSize, Graphics2D G)
-  //      {
-  //          Ellipse2D.Float stone = new Ellipse2D.Float(x,y,pixSize,pixSize);
-  //          G.setColor(player);
-  //          G.fill(stone);
-  //          G.setColor(Color.black);
-  //          G.draw(stone);
-  //      }
-
-  // paint a stone at a given coordinate specified in pixels
-
   public void paintStone(int x, int y, Color player,
                          int pixSize, Graphics g) {
     //System.out.println("by pixel"+x+","+y);

--- a/src/main/java/leelawatcher/gui/ImageMaker.java
+++ b/src/main/java/leelawatcher/gui/ImageMaker.java
@@ -17,11 +17,20 @@
 package leelawatcher.gui;
 
 import leelawatcher.TsbConstants;
-import leelawatcher.goboard.move.Move;
-import leelawatcher.goboard.Position;
 import leelawatcher.goboard.PointOfPlay;
+import leelawatcher.goboard.Position;
+import leelawatcher.goboard.move.AbstractMoveNode;
 
-import java.awt.*;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.MediaTracker;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.TexturePaint;
+import java.awt.Toolkit;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Line2D;
 import java.awt.image.BufferedImage;
@@ -271,7 +280,7 @@ public class ImageMaker implements TsbConstants {
     PointOfPlay lastMove = pos.getLastMove();
 
     float offsetFacor = ((lastPlayedDotScaledDownFactor/2)-1)/lastPlayedDotScaledDownFactor;
-    if (lastMove != null && !Move.isPass(lastMove.getX(),lastMove.getY())) {
+    if (lastMove != null && !AbstractMoveNode.isPass(lastMove.getX(),lastMove.getY())) {
         BGraphs.setColor(pos.blackAt(lastMove.getX(), lastMove.getY()) ? Color.white : Color.black);
         BGraphs.fillOval(Math.round((lineSp / 2 + lastMove.getX() * lineSp)+stnSize*offsetFacor),
                          Math.round((lineSp / 2 + ((size - 1) - lastMove.getY()) * lineSp)+stnSize*offsetFacor),

--- a/src/main/java/leelawatcher/gui/ImageMaker.java
+++ b/src/main/java/leelawatcher/gui/ImageMaker.java
@@ -17,7 +17,7 @@
 package leelawatcher.gui;
 
 import leelawatcher.TsbConstants;
-import leelawatcher.goboard.Move;
+import leelawatcher.goboard.move.Move;
 import leelawatcher.goboard.Position;
 import leelawatcher.goboard.PointOfPlay;
 

--- a/src/main/java/leelawatcher/gui/LeelaWatcher.java
+++ b/src/main/java/leelawatcher/gui/LeelaWatcher.java
@@ -110,12 +110,15 @@ public class LeelaWatcher {
                 JScrollBar vertical = leelaWatcher.textScrollPane.getVerticalScrollBar();
                 vertical.setValue(vertical.getMaximum());
               }
-              if ("inProgress".equals(evt.getPropertyName())) {
+              else if ("inProgress".equals(evt.getPropertyName())) {
                 if (Objects.equals(evt.getNewValue(), false)) {
                   if (!dontSaveGames) {
                     leelaWatcher.boardView.saveGame();
                   }
                 }
+              }
+              else {
+                System.out.println("Unexpected propertyName: " + evt.getPropertyName());
               }
             });
           leelaWatcher.parser.start(new BufferedInputStream(proc.getInputStream()));

--- a/src/main/java/leelawatcher/parser/AutoGtpOutputParser.java
+++ b/src/main/java/leelawatcher/parser/AutoGtpOutputParser.java
@@ -28,15 +28,21 @@ import java.util.regex.Pattern;
 
 public class AutoGtpOutputParser {
 
-  /*
-   * This pattern is meant to report a match for one of 3 groups:
-   * 1. anything ending in 'set.'
+  /**
    * (?:[BW]\\s)? is added so that both AutoGTPv11 outputs (B A1) (W F18) and AutoGTPv9 outputs (A1) (F18) will work.
    */
+  private static final String MOVE_PATTERN = "\\s*\\d+\\s*\\((?:[BW]\\s)?(\\w+)\\)\\s*";
+  /*
+   * This pattern is meant to report a match for one of 3 groups:
+   * 1. Anything ending in 'set.' or 'sent.'
+   *    'set. was used prior to v18, but somewhere around v18 the initial text ended with 'sent.'
+   * 2. A game move
+   * 3. "Game"
+   */
   private static final Pattern EVENT =
-          Pattern.compile("^(.*set\\.|\\s*\\d+\\s\\((?:[BW]\\s)?(\\w+)\\)\\s*|Game).*", Pattern.DOTALL);
+          Pattern.compile("^(.*sent\\.|.*set\\.|" + MOVE_PATTERN + "|Game).*", Pattern.DOTALL);
   private static final Pattern MOVE_EVENT =
-          Pattern.compile("\\s*\\d+\\s*\\((?:[BW]\\s)?(\\w+)\\)\\s*");
+          Pattern.compile(MOVE_PATTERN);
 
   private static final Pattern MOVE = Pattern.compile("(?:(.)(\\d+))|(pass)|(resign)");
   private BoardView boardView;
@@ -98,6 +104,7 @@ public class AutoGtpOutputParser {
             // we got something other than a move, therefore the game is over
             // setting this to false causes the game to be saved to disk.
             setInProgress(false);
+            System.out.println("got something other than a move: \n" + event);
           }
         }
       } catch (IllegalMoveException e) {

--- a/src/main/java/leelawatcher/parser/AutoGtpOutputParser.java
+++ b/src/main/java/leelawatcher/parser/AutoGtpOutputParser.java
@@ -31,9 +31,13 @@ public class AutoGtpOutputParser {
   /*
    * This pattern is meant to report a match for one of 3 groups:
    * 1. anything ending in 'set.'
+   * (?:[BW]\\s)? is added so that both AutoGTPv11 outputs (B A1) (W F18) and AutoGTPv9 outputs (A1) (F18) will work.
    */
-  private static final Pattern EVENT = Pattern.compile("^(.*set\\.|\\s*\\d+\\s\\(\\w+\\)\\s*|Game).*", Pattern.DOTALL);
-  private static final Pattern MOVE_EVENT = Pattern.compile("\\s*\\d+\\s*\\((\\w+)\\)\\s*");
+  private static final Pattern EVENT =
+          Pattern.compile("^(.*set\\.|\\s*\\d+\\s\\((?:[BW]\\s)?(\\w+)\\)\\s*|Game).*", Pattern.DOTALL);
+  private static final Pattern MOVE_EVENT =
+          Pattern.compile("\\s*\\d+\\s*\\((?:[BW]\\s)?(\\w+)\\)\\s*");
+
   private static final Pattern MOVE = Pattern.compile("(?:(.)(\\d+))|(pass)|(resign)");
   private BoardView boardView;
   private boolean inProgress = false;

--- a/src/main/java/leelawatcher/scorer/QuickRules.java
+++ b/src/main/java/leelawatcher/scorer/QuickRules.java
@@ -17,6 +17,7 @@
 package leelawatcher.scorer;
 
 import leelawatcher.goboard.*;
+import leelawatcher.goboard.move.Move;
 
 import java.util.Iterator;
 

--- a/src/main/java/leelawatcher/scorer/QuickRules.java
+++ b/src/main/java/leelawatcher/scorer/QuickRules.java
@@ -16,8 +16,13 @@
 
 package leelawatcher.scorer;
 
-import leelawatcher.goboard.*;
+import leelawatcher.goboard.Board;
+import leelawatcher.goboard.MarkablePosition;
+import leelawatcher.goboard.PointOfPlay;
+import leelawatcher.goboard.Position;
 import leelawatcher.goboard.move.Move;
+import leelawatcher.goboard.move.MoveNode;
+import leelawatcher.goboard.move.RootNode;
 
 import java.util.Iterator;
 
@@ -35,9 +40,9 @@ public class QuickRules extends AbstractRules {
     // we must build a MarkablePosition that shows the board as it would be
     // if the stone were placed in order to test if this would result in self
     // capture (illegal in most rules of the game)
-    Move tmpRoot = new Move();
+    Move tmpRoot = new RootNode();
     char color = board.isWhiteMove() ? Move.MOVE_WHITE : Move.MOVE_BLACK;
-    Move testMove = new Move(p.getX(), p.getY(), color, tmpRoot);
+    Move testMove = new MoveNode(p.getX(), p.getY(), color, tmpRoot);
     Position tmpPos = new Position(board.getCurrPos(), testMove);
     MarkablePosition testMPos = new MarkablePosition(tmpPos);
     //testMPos.dPrint();
@@ -82,7 +87,7 @@ public class QuickRules extends AbstractRules {
   }
 
   public boolean isKo(PointOfPlay p, Board board) {
-    Move tmproot = new Move();
+    Move tmproot = new RootNode();
     int stonesRemoved = 0;
     char color = Move.MOVE_BLACK;
 
@@ -98,7 +103,7 @@ public class QuickRules extends AbstractRules {
     if (board.isWhiteMove()) {
       color = Move.MOVE_WHITE;
     }
-    testMove = new Move(p.getX(), p.getY(), color, tmproot);
+    testMove = new MoveNode(p.getX(), p.getY(), color, tmproot);
     tmpPos = new Position(board.getCurrPos(), testMove);
     testMPos = new MarkablePosition(tmpPos);
 
@@ -146,7 +151,7 @@ public class QuickRules extends AbstractRules {
 
     //System.out.println(stonesRemoved);
     if (stonesRemoved == 1) {
-      for (Iterator i = board.getPosIter(); i.hasNext(); ) {
+      for (Iterator<Position> i = board.getPosIter(); i.hasNext(); ) {
         if (i.next().equals(testMPos)) {
           return true;
         }

--- a/src/main/java/leelawatcher/sgf/SGFbuilder.java
+++ b/src/main/java/leelawatcher/sgf/SGFbuilder.java
@@ -18,7 +18,7 @@ package leelawatcher.sgf;
 
 import leelawatcher.TsbConstants;
 import leelawatcher.goboard.Game;
-import leelawatcher.goboard.Move;
+import leelawatcher.goboard.move.Move;
 
 // This class is meant to simply provide a routine for converting a game object
 // to a string that conforms to SGF FF[4]. game.java extends this class

--- a/src/main/resources/usage.docopts.txt
+++ b/src/main/resources/usage.docopts.txt
@@ -1,10 +1,10 @@
 Start a LeelaWatcher instance. A prefix of java -jar is presumed for all
 usage below. <dir> specifies where to find autogtp and <cmd> allows
-overide of default './autogtp' command (windows users need to specify
+override of default './autogtp' command (windows users need to specify
 an exe for example)
 
 Usage:
- LeelaWatcher-1.1.0-SNAPSHOT.jar [--help] [options] <dir> [<cmd>]
+ LeelaWatcher-1.2.0-SNAPSHOT.jar [--help] [options] <dir> [<cmd>]
 
 Options:
   --no-sgf        Don't save an sgf file for each game

--- a/src/test/java/leelawatcher/goboard/MarkablePositionTest.java
+++ b/src/test/java/leelawatcher/goboard/MarkablePositionTest.java
@@ -1,14 +1,17 @@
 package leelawatcher.goboard;
 
 import leelawatcher.goboard.move.Move;
+import leelawatcher.goboard.move.MoveNode;
+import leelawatcher.goboard.move.RootNode;
 import org.junit.Test;
 
 import java.util.Set;
 
+import static leelawatcher.goboard.move.Move.MOVE_BLACK;
+import static leelawatcher.goboard.move.Move.MOVE_WHITE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static leelawatcher.goboard.move.Move.*;
 
 
 /**
@@ -66,26 +69,26 @@ public class MarkablePositionTest {
     public void testGetGroup1Set() {
 
         Position pos = new Position();
-        Move root = new Move();
-        pos = new Position(pos, new Move(2, 2, MOVE_BLACK, root));
+        Move root = new RootNode();
+        pos = new Position(pos, new MoveNode(2, 2, MOVE_BLACK, root));
         MarkablePosition mp = new MarkablePosition(pos);
 
-        Set members = mp.getGroupSet(new PointOfPlay(2, 2), null, 9);
+        Set<PointOfPlay> members = mp.getGroupSet(new PointOfPlay(2, 2), null, 9);
         assertEquals("Unexpected number of members",1, members.size());
     }
 
     @Test
     public void testGetGroup3Set() {
         Position pos = new Position();
-        Move root = new Move();
-        pos = new Position(pos, new Move(2, 2, MOVE_BLACK, root));
-        pos = new Position(pos, new Move(2, 5, MOVE_WHITE, root));
-        pos = new Position(pos, new Move(2, 3, MOVE_BLACK, root));
-        pos = new Position(pos, new Move(6, 5, MOVE_WHITE, root));
-        pos = new Position(pos, new Move(3, 3, MOVE_BLACK, root));
+        Move root = new RootNode();
+        pos = new Position(pos, new MoveNode(2, 2, MOVE_BLACK, root));
+        pos = new Position(pos, new MoveNode(2, 5, MOVE_WHITE, root));
+        pos = new Position(pos, new MoveNode(2, 3, MOVE_BLACK, root));
+        pos = new Position(pos, new MoveNode(6, 5, MOVE_WHITE, root));
+        pos = new Position(pos, new MoveNode(3, 3, MOVE_BLACK, root));
         MarkablePosition mp = new MarkablePosition(pos);
 
-        Set members = mp.getGroupSet(new PointOfPlay(2, 2), null, 9);
+        Set<PointOfPlay> members = mp.getGroupSet(new PointOfPlay(2, 2), null, 9);
         assertEquals("Unexpected number of members",3, members.size());
     }
 

--- a/src/test/java/leelawatcher/goboard/MarkablePositionTest.java
+++ b/src/test/java/leelawatcher/goboard/MarkablePositionTest.java
@@ -1,5 +1,6 @@
 package leelawatcher.goboard;
 
+import leelawatcher.goboard.move.Move;
 import org.junit.Test;
 
 import java.util.Set;
@@ -7,7 +8,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static leelawatcher.goboard.Move.*;
+import static leelawatcher.goboard.move.Move.*;
 
 
 /**

--- a/src/test/java/leelawatcher/scorer/QuickRulesTest.java
+++ b/src/test/java/leelawatcher/scorer/QuickRulesTest.java
@@ -2,7 +2,7 @@ package leelawatcher.scorer;
 
 import leelawatcher.goboard.Board;
 import leelawatcher.goboard.IllegalMoveException;
-import leelawatcher.goboard.Move;
+import leelawatcher.goboard.move.Move;
 import leelawatcher.goboard.PointOfPlay;
 import org.junit.Test;
 


### PR DESCRIPTION
The EVENT parser is pretty fragile in the sense that if the initial text sent by autogtp changes at all, it can fail in a mysterious way. I updated the regexp to accept the new text and still be backward compatible with old versions, but it could fail again in the future
if the autogtp start text changes again.

I bumped the version to 1.2.0 and also updated to gradle 6.2 and a newer version of the fatjar plugin. You can now build with java 11. A new l release will need to be created and posted.

I tested against the v16 and v17 versions of the leela-zero distribution.